### PR TITLE
Improve macro placeholder check

### DIFF
--- a/url_swap1.html
+++ b/url_swap1.html
@@ -584,6 +584,10 @@
         default:            return null;
       }
     }
+
+    function isPlaceholderValue(val) {
+      return (/^\{[^{}]+\}$/).test(val) || (/^\[[^\[\]]+\]$/).test(val);
+    }
   
     /***********************************************
      * 3) APPLY TABLE ROW REPLACEMENTS (macros)
@@ -612,8 +616,8 @@
           if (lowerKey in lowerCaseKeyMap) {
             const actualKey = lowerCaseKeyMap[lowerKey];
             const existingValue = currentParams[actualKey] || '';
-            // Replace only if it's obviously a placeholder (contains { } or [ ])
-            if (existingValue.includes('{') || existingValue.includes('[')) {
+            // Replace only if the current value is an actual placeholder
+            if (isPlaceholderValue(existingValue)) {
               currentParams[actualKey] = row.macro;
             }
           } else {


### PR DESCRIPTION
## Summary
- add `isPlaceholderValue` helper for stricter macro detection
- use this helper in `applyTableRowReplacements`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848ec3f68b88325a9f3de8f4c0544c1